### PR TITLE
Reverted code to return Null instead of Exception for types that cannot be converted

### DIFF
--- a/src/main/java/jp/co/yahoo/yosegi/message/objects/avro/AvroObjectToPrimitiveObject.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/objects/avro/AvroObjectToPrimitiveObject.java
@@ -42,7 +42,12 @@ public class AvroObjectToPrimitiveObject {
    * Convert Avro object to PrimitiveObject.
    */
   public static PrimitiveObject get( final Object obj ) throws IOException, AvroTypeException {
-    Schema.Type schemaType = genericUtil.induce( obj ).getType();;
+    Schema.Type schemaType;
+    try {
+      schemaType = genericUtil.induce( obj ).getType();
+    } catch ( AvroTypeException ex ) {
+      return NullObj.getInstance();
+    }
 
     if ( schemaType == Schema.Type.BOOLEAN ) {
       return new BooleanObj( (Boolean)obj );

--- a/src/test/java/jp/co/yahoo/yosegi/message/objects/avro/TestAvroObjectToPrimitiveObject.java
+++ b/src/test/java/jp/co/yahoo/yosegi/message/objects/avro/TestAvroObjectToPrimitiveObject.java
@@ -122,8 +122,15 @@ public class TestAvroObjectToPrimitiveObject {
   }
 
   @Test
-  public void T_convertUnknownObj_throwsException() throws IOException {
-    assertThrows( AvroTypeException.class , () -> AvroObjectToPrimitiveObject.get( new BooleanObj( true ) ) );
+  public void T_convertEmptyArrayObj_isNull() throws IOException {
+    PrimitiveObject obj = AvroObjectToPrimitiveObject.get( Arrays.asList() );
+    assertTrue( obj instanceof NullObj );
+  }
+
+  @Test
+  public void T_convertUnknownObj_isNull() throws IOException {
+    PrimitiveObject obj = AvroObjectToPrimitiveObject.get( new StringObj( "" ) );
+    assertTrue( obj instanceof NullObj );
   }
 
 }


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

Empty arrays, which are considered normal types, are an exception in this process.
Since it is difficult for the caller to control the exception, it should be NULL when an exception occurs.

### How did you do the test? (Not required for updating documents)
