### PR TITLE
Fixed bug where size() was 0 for Struct even though the column existed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>jp.co.yahoo.yosegi</groupId>
   <artifactId>yosegi-avro</artifactId>
-  <version>0.9.3-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Yosegi avro</name>
   <description>Yosegi avro package.</description>
@@ -81,12 +81,12 @@
     <dependency>
       <groupId>jp.co.yahoo.yosegi</groupId>
       <artifactId>yosegi</artifactId>
-      <version>0.9.0</version>
+      <version>2.0.11</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.7.7</version>
+      <version>1.11.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/jp/co/yahoo/yosegi/message/parser/avro/AvroRecordParser.java
+++ b/src/main/java/jp/co/yahoo/yosegi/message/parser/avro/AvroRecordParser.java
@@ -78,7 +78,7 @@ public class AvroRecordParser implements IParser {
 
   @Override
   public int size() throws IOException {
-    return 0;
+    return record.getSchema().getFields().size();
   }
 
   @Override

--- a/src/test/java/jp/co/yahoo/yosegi/message/TestAvroDataUtil.java
+++ b/src/test/java/jp/co/yahoo/yosegi/message/TestAvroDataUtil.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jp.co.yahoo.yosegi.message;
+
+import jp.co.yahoo.yosegi.message.design.IField;
+import jp.co.yahoo.yosegi.message.formatter.avro.AvroMessageWriter;
+import jp.co.yahoo.yosegi.message.parser.IParser;
+import jp.co.yahoo.yosegi.message.parser.json.JacksonMessageReader;
+
+import java.io.IOException;
+
+public final class TestAvroDataUtil {
+
+  public static byte[] jsonToAvro( final String json ,final IField schema ) throws IOException {
+    return new AvroMessageWriter( schema ).create(
+        new JacksonMessageReader().create( json ) );
+  }
+
+}

--- a/src/test/java/jp/co/yahoo/yosegi/message/parser/avro/TestAvroRecordParser.java
+++ b/src/test/java/jp/co/yahoo/yosegi/message/parser/avro/TestAvroRecordParser.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jp.co.yahoo.yosegi.message.parser.avro;
+
+import jp.co.yahoo.yosegi.message.TestAvroDataUtil;
+import jp.co.yahoo.yosegi.message.parser.IParser;
+import jp.co.yahoo.yosegi.message.parser.json.JacksonMessageReader;
+import jp.co.yahoo.yosegi.message.design.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestAvroRecordParser {
+
+  @Test
+  public void T_checkAllFields() throws IOException{
+    String json = "{ \"struct_col\": { \"col1\":1, \"col2\":2, \"col3\":3 } }";
+    StructContainerField schema = new StructContainerField( "root" );
+    StructContainerField structCol = new StructContainerField( "struct_col" );
+    structCol.set( new IntegerField( "col1" ) );
+    structCol.set( new IntegerField( "col2" ) );
+    structCol.set( new IntegerField( "col3" ) );
+    schema.set( structCol );
+    byte[] avro = TestAvroDataUtil.jsonToAvro( json , schema );
+    AvroMessageReader avroReader = new AvroMessageReader( schema );
+    IParser avroParser = avroReader.create( avro );
+    IParser jsonParser = new JacksonMessageReader().create( json );
+    assertEquals( avroParser.size() , jsonParser.size() );
+
+    IParser avroStructParser = avroParser.getParser( "struct_col" );
+    IParser jsonStructParser = jsonParser.getParser( "struct_col" );
+    assertEquals( avroStructParser.size() , 3 );
+    assertEquals( avroStructParser.size() , jsonStructParser.size() );
+    for ( String key : jsonStructParser.getAllKey() ) {
+      assertEquals( avroStructParser.get( key ).getInt() , jsonStructParser.get( key ).getInt() );
+    }
+  }
+}


### PR DESCRIPTION
### What is the necessity of this update? What is updated?

A size of 0 may be returned, causing the field to be recognized as empty, such as when referencing all keys.

### How did you do the test? (Not required for updating documents)

I created a unit test.
